### PR TITLE
Show plugin version in dashboard

### DIFF
--- a/.changeset/show-dashboard-plugin-version.md
+++ b/.changeset/show-dashboard-plugin-version.md
@@ -1,0 +1,5 @@
+---
+"@thelioo/opencode-balancer": patch
+---
+
+Show the plugin version in the dashboard title.

--- a/src/tui/components/dashboard.tsx
+++ b/src/tui/components/dashboard.tsx
@@ -9,6 +9,7 @@ import {
 	onMount,
 	Show,
 } from "solid-js";
+import packageJson from "../../../package.json" with { type: "json" };
 import { listAccounts } from "../../core/accounts";
 import { getBalancingEnabled, setBalancingEnabled } from "../../core/priority";
 import { getUsageSnapshot } from "../../core/usage/store";
@@ -314,7 +315,8 @@ export function Dashboard(props: {
 		>
 			<box flexDirection="column" flexShrink={0} gap={0} paddingBottom={1}>
 				<text fg={theme().primary} overflow="hidden" truncate wrapMode="none">
-					opencode-balancer{compact() ? "" : " control center"}
+					opencode-balancer v{packageJson.version}
+					{compact() ? "" : " control center"}
 				</text>
 				<Show when={!compact()}>
 					<text

--- a/src/tui/components/dashboard.tsx
+++ b/src/tui/components/dashboard.tsx
@@ -316,7 +316,6 @@ export function Dashboard(props: {
 			<box flexDirection="column" flexShrink={0} gap={0} paddingBottom={1}>
 				<text fg={theme().primary} overflow="hidden" truncate wrapMode="none">
 					opencode-balancer v{packageJson.version}
-					{compact() ? "" : " control center"}
 				</text>
 				<Show when={!compact()}>
 					<text

--- a/test/tui/dashboard.test.ts
+++ b/test/tui/dashboard.test.ts
@@ -7,6 +7,22 @@ const expectSourceToContain = (source: string, snippet: string) =>
 	expect(compact(source)).toContain(compact(snippet));
 
 describe("Dashboard", () => {
+	test("renders plugin version in the dashboard title", () => {
+		const source = readFileSync(
+			join(import.meta.dir, "../../src/tui/components/dashboard.tsx"),
+			"utf8",
+		);
+		const packageJson = JSON.parse(
+			readFileSync(join(import.meta.dir, "../../package.json"), "utf8"),
+		) as { version: string };
+
+		expect(packageJson.version).toBeTruthy();
+		expect(source).toContain(
+			'from "../../../package.json" with { type: "json" }',
+		);
+		expectSourceToContain(source, `opencode-balancer v{packageJson.version}`);
+	});
+
 	test("renders new account as an accounts row instead of a header action", () => {
 		const source = readFileSync(
 			join(import.meta.dir, "../../src/tui/components/dashboard.tsx"),


### PR DESCRIPTION
## Summary
- Show the package version in the dashboard title.
- Add dashboard coverage for the version title.
- Add a patch changeset for release.

## Test Plan
- bun test
- bun run checktypes
- bun run build
- bun run lint