### PR TITLE
Invalidate stale latest plugin cache

### DIFF
--- a/.changeset/specific-cache-invalidation.md
+++ b/.changeset/specific-cache-invalidation.md
@@ -1,0 +1,5 @@
+---
+"@thelioo/opencode-balancer": patch
+---
+
+Invalidate only the active outdated `@latest` opencode plugin cache sandbox after detecting a newer npm release, then notify the user to restart opencode.

--- a/src/server/cache-update.ts
+++ b/src/server/cache-update.ts
@@ -1,0 +1,177 @@
+import { existsSync, readFileSync, rmSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+
+type PackageJson = {
+	name?: string;
+	version?: string;
+};
+
+export type CacheInvalidationInput = {
+	cacheDir?: string;
+	currentVersion: string;
+	latestVersion: string;
+	moduleUrl: string;
+	packageName: string;
+};
+
+export type CacheInvalidationResult = {
+	removed: string[];
+	reason?: string;
+};
+
+export type CacheUpdateCheckInput = Omit<
+	CacheInvalidationInput,
+	"latestVersion"
+> & {
+	fetchLatestVersion?: () => Promise<string | undefined>;
+	notify?: (message: string) => Promise<unknown>;
+};
+
+function opencodeCacheDir() {
+	if (process.env.XDG_CACHE_HOME)
+		return join(process.env.XDG_CACHE_HOME, "opencode");
+	if (process.platform === "darwin") {
+		return join(homedir(), "Library", "Caches", "opencode");
+	}
+	if (process.platform === "win32") {
+		return join(
+			process.env.LOCALAPPDATA ?? join(homedir(), "AppData", "Local"),
+			"opencode",
+		);
+	}
+	return join(homedir(), ".cache", "opencode");
+}
+
+function readPackageJson(file: string): PackageJson | undefined {
+	try {
+		return JSON.parse(readFileSync(file, "utf8")) as PackageJson;
+	} catch {
+		return;
+	}
+}
+
+function packagePathSegments(packageName: string) {
+	return packageName.split("/").filter(Boolean);
+}
+
+function findInstalledPackageDir(file: string, packageName: string) {
+	const segments = packagePathSegments(packageName);
+	let current = file;
+	while (current !== dirname(current)) {
+		if (
+			segments.every((segment, index) => {
+				const parts = current.split(sep);
+				return parts[parts.length - segments.length + index] === segment;
+			})
+		) {
+			if (current.split(sep).at(-(segments.length + 1)) === "node_modules") {
+				return current;
+			}
+		}
+		current = dirname(current);
+	}
+}
+
+function isPathInside(child: string, parent: string) {
+	const normalizedParent = parent.endsWith(sep) ? parent : `${parent}${sep}`;
+	return child === parent || child.startsWith(normalizedParent);
+}
+
+function isLatestSandbox(sandboxRoot: string, packageName: string) {
+	return sandboxRoot.split(sep).join("/").endsWith(`${packageName}@latest`);
+}
+
+export function invalidateOutdatedPackageCache({
+	cacheDir = opencodeCacheDir(),
+	currentVersion,
+	latestVersion,
+	moduleUrl,
+	packageName,
+}: CacheInvalidationInput): CacheInvalidationResult {
+	if (!currentVersion || !latestVersion || currentVersion === latestVersion) {
+		return { reason: "up-to-date", removed: [] };
+	}
+
+	let moduleFile: string;
+	try {
+		moduleFile = moduleUrl.startsWith("file://")
+			? fileURLToPath(moduleUrl)
+			: moduleUrl;
+	} catch {
+		return { reason: "invalid-module-url", removed: [] };
+	}
+
+	const installedPackageDir = findInstalledPackageDir(moduleFile, packageName);
+	if (!installedPackageDir)
+		return { reason: "package-dir-not-found", removed: [] };
+
+	const nodeModulesDir = dirname(dirname(installedPackageDir));
+	if (nodeModulesDir.split(sep).at(-1) !== "node_modules") {
+		return { reason: "node-modules-not-found", removed: [] };
+	}
+
+	const sandboxRoot = dirname(nodeModulesDir);
+	const packagesDir = join(cacheDir, "packages");
+	if (!isPathInside(sandboxRoot, packagesDir)) {
+		return { reason: "outside-opencode-packages-cache", removed: [] };
+	}
+	if (!isLatestSandbox(sandboxRoot, packageName)) {
+		return { reason: "not-latest-sandbox", removed: [] };
+	}
+
+	const packageJson = readPackageJson(
+		join(installedPackageDir, "package.json"),
+	);
+	if (
+		packageJson?.name !== packageName ||
+		packageJson.version !== currentVersion
+	) {
+		return { reason: "version-mismatch", removed: [] };
+	}
+
+	if (!existsSync(sandboxRoot))
+		return { reason: "sandbox-missing", removed: [] };
+	rmSync(sandboxRoot, { force: true, recursive: true });
+	return { removed: [sandboxRoot] };
+}
+
+export async function fetchNpmLatestVersion(packageName: string) {
+	try {
+		const response = await fetch(
+			`https://registry.npmjs.org/-/package/${encodeURIComponent(packageName)}/dist-tags`,
+			{ headers: { accept: "application/json" } },
+		);
+		if (!response.ok) return;
+		const data = (await response.json()) as { latest?: unknown };
+		return typeof data.latest === "string" ? data.latest : undefined;
+	} catch {
+		return;
+	}
+}
+
+export async function checkAndInvalidateOutdatedPackageCache({
+	fetchLatestVersion,
+	notify,
+	...input
+}: CacheUpdateCheckInput): Promise<CacheInvalidationResult> {
+	const latestVersion = await (
+		fetchLatestVersion ?? (() => fetchNpmLatestVersion(input.packageName))
+	)();
+	if (!latestVersion)
+		return { reason: "latest-version-unavailable", removed: [] };
+
+	const result = invalidateOutdatedPackageCache({
+		...input,
+		latestVersion,
+	});
+
+	if (result.removed.length > 0) {
+		await notify?.(
+			`opencode-balancer v${latestVersion} is ready. Restart opencode to update from v${input.currentVersion}.`,
+		);
+	}
+
+	return result;
+}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -5,6 +5,7 @@ import {
 	type Plugin,
 	tool,
 } from "@opencode-ai/plugin";
+import packageJson from "../../package.json" with { type: "json" };
 import {
 	getActiveAccount,
 	getSelectedAccount,
@@ -15,6 +16,7 @@ import { openBalancerDatabase } from "../core/database";
 import { storePath } from "../core/path";
 import { getBalancingEnabled, resolveActiveSelection } from "../core/priority";
 import { migrate } from "../core/schema";
+import { checkAndInvalidateOutdatedPackageCache } from "./cache-update";
 import { runFallbackBalancerCommand } from "./commands";
 import { installFetchPatch } from "./fetch-patch";
 import { setNativeAuth, showToast } from "./native";
@@ -23,6 +25,8 @@ import {
 	INTERNAL_REQUEST_HEADER,
 	setPendingRequest,
 } from "./request-balancer";
+
+const PACKAGE_NAME = "@thelioo/opencode-balancer";
 
 export function configureFallbackCommand(cfg: Config) {
 	if (!cfg.command?.balancer) return;
@@ -129,6 +133,12 @@ export const serverPlugin = (async ({ client }) => {
 	const db = openBalancerDatabase(storePath());
 	migrate(db);
 	installFetchPatch(db, client);
+	checkAndInvalidateOutdatedPackageCache({
+		currentVersion: packageJson.version,
+		moduleUrl: import.meta.url,
+		notify: (message) => showToast(client, message, "success"),
+		packageName: PACKAGE_NAME,
+	}).catch(() => {});
 
 	return createServerHooks({ client, db });
 }) satisfies Plugin;

--- a/test/server/cache-update.test.ts
+++ b/test/server/cache-update.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import {
+	checkAndInvalidateOutdatedPackageCache,
+	invalidateOutdatedPackageCache,
+} from "../../src/server/cache-update";
+
+const PACKAGE_NAME = "@thelioo/opencode-balancer";
+
+function writePackageJson(file: string, data: Record<string, unknown>) {
+	mkdirSync(join(file, ".."), { recursive: true });
+	writeFileSync(file, JSON.stringify(data, null, 2));
+}
+
+function createCachedPackage(cacheDir: string, spec: string, version: string) {
+	const root = join(cacheDir, "packages", spec);
+	const packageDir = join(
+		root,
+		"node_modules",
+		"@thelioo",
+		"opencode-balancer",
+	);
+	writePackageJson(join(root, "package.json"), {
+		dependencies: { [PACKAGE_NAME]: version },
+	});
+	writePackageJson(join(packageDir, "package.json"), {
+		name: PACKAGE_NAME,
+		version,
+	});
+	mkdirSync(join(packageDir, "dist"), { recursive: true });
+	writeFileSync(join(packageDir, "dist", "index.js"), "export default {};\n");
+	return { packageDir, root };
+}
+
+describe("cache update invalidation", () => {
+	test("removes only the active latest sandbox for the exact outdated version", () => {
+		const dir = join(
+			tmpdir(),
+			`opencode-balancer-cache-${crypto.randomUUID()}`,
+		);
+		try {
+			const latest = createCachedPackage(
+				dir,
+				"@thelioo/opencode-balancer@latest",
+				"0.2.2",
+			);
+			const pinned = createCachedPackage(
+				dir,
+				"@thelioo/opencode-balancer@0.1.6",
+				"0.1.6",
+			);
+
+			const result = invalidateOutdatedPackageCache({
+				cacheDir: dir,
+				currentVersion: "0.2.2",
+				latestVersion: "0.2.3",
+				moduleUrl: pathToFileURL(join(latest.packageDir, "dist", "index.js"))
+					.href,
+				packageName: PACKAGE_NAME,
+			});
+
+			expect(result.removed).toEqual([latest.root]);
+			expect(existsSync(latest.root)).toBe(false);
+			expect(existsSync(pinned.root)).toBe(true);
+		} finally {
+			rmSync(dir, { force: true, recursive: true });
+		}
+	});
+
+	test("does not remove pinned sandboxes even when their package version is outdated", () => {
+		const dir = join(
+			tmpdir(),
+			`opencode-balancer-cache-${crypto.randomUUID()}`,
+		);
+		try {
+			const pinned = createCachedPackage(
+				dir,
+				"@thelioo/opencode-balancer@0.2.2",
+				"0.2.2",
+			);
+
+			const result = invalidateOutdatedPackageCache({
+				cacheDir: dir,
+				currentVersion: "0.2.2",
+				latestVersion: "0.2.3",
+				moduleUrl: pathToFileURL(join(pinned.packageDir, "dist", "index.js"))
+					.href,
+				packageName: PACKAGE_NAME,
+			});
+
+			expect(result.removed).toEqual([]);
+			expect(existsSync(pinned.root)).toBe(true);
+		} finally {
+			rmSync(dir, { force: true, recursive: true });
+		}
+	});
+
+	test("does not remove a latest sandbox whose installed package version does not match the loaded version", () => {
+		const dir = join(
+			tmpdir(),
+			`opencode-balancer-cache-${crypto.randomUUID()}`,
+		);
+		try {
+			const latest = createCachedPackage(
+				dir,
+				"@thelioo/opencode-balancer@latest",
+				"0.2.1",
+			);
+
+			const result = invalidateOutdatedPackageCache({
+				cacheDir: dir,
+				currentVersion: "0.2.2",
+				latestVersion: "0.2.3",
+				moduleUrl: pathToFileURL(join(latest.packageDir, "dist", "index.js"))
+					.href,
+				packageName: PACKAGE_NAME,
+			});
+
+			expect(result.removed).toEqual([]);
+			expect(existsSync(latest.root)).toBe(true);
+		} finally {
+			rmSync(dir, { force: true, recursive: true });
+		}
+	});
+
+	test("checks latest version, invalidates the exact cache, and notifies for restart", async () => {
+		const dir = join(
+			tmpdir(),
+			`opencode-balancer-cache-${crypto.randomUUID()}`,
+		);
+		try {
+			const latest = createCachedPackage(
+				dir,
+				"@thelioo/opencode-balancer@latest",
+				"0.2.2",
+			);
+			const toasts: string[] = [];
+
+			const result = await checkAndInvalidateOutdatedPackageCache({
+				cacheDir: dir,
+				currentVersion: "0.2.2",
+				fetchLatestVersion: async () => "0.2.3",
+				moduleUrl: pathToFileURL(join(latest.packageDir, "dist", "index.js"))
+					.href,
+				notify: async (message) => toasts.push(message),
+				packageName: PACKAGE_NAME,
+			});
+
+			expect(result.removed).toEqual([latest.root]);
+			expect(existsSync(latest.root)).toBe(false);
+			expect(toasts).toEqual([
+				"opencode-balancer v0.2.3 is ready. Restart opencode to update from v0.2.2.",
+			]);
+		} finally {
+			rmSync(dir, { force: true, recursive: true });
+		}
+	});
+
+	test("does not invalidate cache when the latest version check fails", async () => {
+		const dir = join(
+			tmpdir(),
+			`opencode-balancer-cache-${crypto.randomUUID()}`,
+		);
+		try {
+			const latest = createCachedPackage(
+				dir,
+				"@thelioo/opencode-balancer@latest",
+				"0.2.2",
+			);
+			const toasts: string[] = [];
+
+			const result = await checkAndInvalidateOutdatedPackageCache({
+				cacheDir: dir,
+				currentVersion: "0.2.2",
+				fetchLatestVersion: async () => undefined,
+				moduleUrl: pathToFileURL(join(latest.packageDir, "dist", "index.js"))
+					.href,
+				notify: async (message) => toasts.push(message),
+				packageName: PACKAGE_NAME,
+			});
+
+			expect(result.removed).toEqual([]);
+			expect(result.reason).toBe("latest-version-unavailable");
+			expect(existsSync(latest.root)).toBe(true);
+			expect(toasts).toEqual([]);
+		} finally {
+			rmSync(dir, { force: true, recursive: true });
+		}
+	});
+});


### PR DESCRIPTION
## Summary
- Add startup update check for npm latest version of @thelioo/opencode-balancer.
- Invalidate only the active @latest opencode cache sandbox when its installed package version exactly matches the stale loaded version.
- Notify the user to restart opencode after the stale cache is removed.

## Test Plan
- bun test
- bun run lint
- bun run checktypes
- bun run build