### PR TITLE
Add dummy patch release for auto-update testing

### DIFF
--- a/.changeset/dummy-autoupdate-test.md
+++ b/.changeset/dummy-autoupdate-test.md
@@ -1,0 +1,5 @@
+---
+"@thelioo/opencode-balancer": patch
+---
+
+Publish a dummy patch release to test plugin cache auto-update behavior.


### PR DESCRIPTION
## Summary
- Add a patch changeset only, with no runtime behavior changes.
- Intended to publish a new version so the plugin cache auto-update path can be tested against an older cached version.

## Test Plan
- Commit hooks ran: tsgo --noEmit, biome check ., bun test, bun scripts/build.ts