### PR TITLE
Defer plugin cache update check

### DIFF
--- a/.changeset/deferred-cache-update-check.md
+++ b/.changeset/deferred-cache-update-check.md
@@ -1,0 +1,5 @@
+---
+"@thelioo/opencode-balancer": patch
+---
+
+Run the plugin cache update check after the first root session is created, matching the deferred startup pattern used by other opencode plugins.

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -41,12 +41,21 @@ function runSafeFallbackBalancerCommand(db: Database, raw: string) {
 }
 
 export function createServerHooks({
+	cacheUpdate,
 	db,
 	client,
 }: {
+	cacheUpdate?: () => Promise<unknown>;
 	db: Database;
 	client: any;
 }): Hooks {
+	let cacheUpdateChecked = false;
+	const runCacheUpdate = () => {
+		if (cacheUpdateChecked) return;
+		cacheUpdateChecked = true;
+		cacheUpdate?.().catch(() => {});
+	};
+
 	return {
 		"chat.headers": async (input, output) => {
 			const providerID = input.model.providerID;
@@ -105,6 +114,11 @@ export function createServerHooks({
 		config: async (cfg) => {
 			configureFallbackCommand(cfg);
 		},
+		event: async ({ event }: any) => {
+			if (event.type !== "session.created") return;
+			if (event.properties?.info?.parentID) return;
+			runCacheUpdate();
+		},
 
 		"experimental.chat.messages.transform": async (_input, output) => {
 			output.messages = output.messages.filter((message) => {
@@ -133,12 +147,16 @@ export const serverPlugin = (async ({ client }) => {
 	const db = openBalancerDatabase(storePath());
 	migrate(db);
 	installFetchPatch(db, client);
-	checkAndInvalidateOutdatedPackageCache({
-		currentVersion: packageJson.version,
-		moduleUrl: import.meta.url,
-		notify: (message) => showToast(client, message, "success"),
-		packageName: PACKAGE_NAME,
-	}).catch(() => {});
 
-	return createServerHooks({ client, db });
+	return createServerHooks({
+		cacheUpdate: () =>
+			checkAndInvalidateOutdatedPackageCache({
+				currentVersion: packageJson.version,
+				moduleUrl: import.meta.url,
+				notify: (message) => showToast(client, message, "success"),
+				packageName: PACKAGE_NAME,
+			}),
+		client,
+		db,
+	});
 }) satisfies Plugin;

--- a/test/server/index.test.ts
+++ b/test/server/index.test.ts
@@ -72,11 +72,36 @@ describe("server plugin config", () => {
 	test("creates fallback balancer hooks and tool", () => {
 		const hooks = createServerHooks({ client: {}, db: db() });
 
+		expect(hooks.event).toBeFunction();
 		expect(hooks.config).toBeFunction();
 		expect(hooks["chat.headers"]).toBeFunction();
 		expect(hooks["command.execute.before"]).toBeFunction();
 		expect(hooks["experimental.chat.messages.transform"]).toBeFunction();
 		expect(hooks.tool?.balancer_command).toBeDefined();
+	});
+
+	test("runs the cache update check once after a root session is created", async () => {
+		const calls: string[] = [];
+		const hooks = createServerHooks({
+			cacheUpdate: async () => calls.push("check"),
+			client: {},
+			db: db(),
+		});
+
+		await hooks.event?.({
+			event: { properties: {}, type: "session.created" },
+		} as any);
+		await hooks.event?.({
+			event: { properties: {}, type: "session.created" },
+		} as any);
+		await hooks.event?.({
+			event: {
+				properties: { info: { parentID: "parent" } },
+				type: "session.created",
+			},
+		} as any);
+
+		expect(calls).toEqual(["check"]);
 	});
 
 	test("chat headers marks requests for active accounts", async () => {


### PR DESCRIPTION
## Summary
- Run the cache update check from the first root session.created event instead of during plugin construction.
- Match the deferred startup pattern used by oh-my-opencode and skip child sessions.
- Add a patch changeset for the fix.

## Test Plan
- bun test
- bun run lint
- bun run checktypes
- bun run build