### PR TITLE
Add second dummy patch release for auto-update testing

### DIFF
--- a/.changeset/dummy-autoupdate-test-2.md
+++ b/.changeset/dummy-autoupdate-test-2.md
@@ -1,0 +1,5 @@
+---
+"@thelioo/opencode-balancer": patch
+---
+
+Publish another dummy patch release to test deferred plugin cache auto-update behavior.


### PR DESCRIPTION
## Summary
- Add a patch changeset only, with no runtime behavior changes.
- Intended to publish another version after the deferred cache update fix so the auto-update path can be tested in practice.

## Test Plan
- Commit hooks ran: tsgo --noEmit, biome check ., bun test, bun scripts/build.ts

## Note
- Merge this after #17 so the dummy release includes the deferred cache update fix from main.