### PR TITLE
fix: run plugin auto-update check on load and on an interval

### DIFF
--- a/.changeset/fix-autoupdate-init-trigger.md
+++ b/.changeset/fix-autoupdate-init-trigger.md
@@ -1,0 +1,8 @@
+---
+"@thelioo/opencode-balancer": patch
+---
+
+Fix the plugin auto-update never running. The check now runs when the plugin
+loads, on every opencode start. Detecting a newer release clears the stale
+cached `@latest` sandbox and opencode reinstalls the new version on its own,
+with no toast or restart prompt.

--- a/src/server/cache-update.ts
+++ b/src/server/cache-update.ts
@@ -26,7 +26,6 @@ export type CacheUpdateCheckInput = Omit<
 	"latestVersion"
 > & {
 	fetchLatestVersion?: () => Promise<string | undefined>;
-	notify?: (message: string) => Promise<unknown>;
 };
 
 function opencodeCacheDir() {
@@ -153,7 +152,6 @@ export async function fetchNpmLatestVersion(packageName: string) {
 
 export async function checkAndInvalidateOutdatedPackageCache({
 	fetchLatestVersion,
-	notify,
 	...input
 }: CacheUpdateCheckInput): Promise<CacheInvalidationResult> {
 	const latestVersion = await (
@@ -162,16 +160,8 @@ export async function checkAndInvalidateOutdatedPackageCache({
 	if (!latestVersion)
 		return { reason: "latest-version-unavailable", removed: [] };
 
-	const result = invalidateOutdatedPackageCache({
+	return invalidateOutdatedPackageCache({
 		...input,
 		latestVersion,
 	});
-
-	if (result.removed.length > 0) {
-		await notify?.(
-			`opencode-balancer v${latestVersion} is ready. Restart opencode to update from v${input.currentVersion}.`,
-		);
-	}
-
-	return result;
 }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -49,12 +49,10 @@ export function createServerHooks({
 	db: Database;
 	client: any;
 }): Hooks {
-	let cacheUpdateChecked = false;
-	const runCacheUpdate = () => {
-		if (cacheUpdateChecked) return;
-		cacheUpdateChecked = true;
-		cacheUpdate?.().catch(() => {});
-	};
+	// opencode caches the `@latest` sandbox and never re-resolves it, so the
+	// bundled version goes stale after a release. Check on load; detecting a
+	// newer release clears the stale sandbox so opencode reinstalls it.
+	cacheUpdate?.().catch(() => {});
 
 	return {
 		"chat.headers": async (input, output) => {
@@ -114,12 +112,6 @@ export function createServerHooks({
 		config: async (cfg) => {
 			configureFallbackCommand(cfg);
 		},
-		event: async ({ event }: any) => {
-			if (event.type !== "session.created") return;
-			if (event.properties?.info?.parentID) return;
-			runCacheUpdate();
-		},
-
 		"experimental.chat.messages.transform": async (_input, output) => {
 			output.messages = output.messages.filter((message) => {
 				return !message.parts.some((part: any) => {
@@ -153,7 +145,6 @@ export const serverPlugin = (async ({ client }) => {
 			checkAndInvalidateOutdatedPackageCache({
 				currentVersion: packageJson.version,
 				moduleUrl: import.meta.url,
-				notify: (message) => showToast(client, message, "success"),
 				packageName: PACKAGE_NAME,
 			}),
 		client,

--- a/test/server/cache-update.test.ts
+++ b/test/server/cache-update.test.ts
@@ -126,7 +126,7 @@ describe("cache update invalidation", () => {
 		}
 	});
 
-	test("checks latest version, invalidates the exact cache, and notifies for restart", async () => {
+	test("checks latest version and invalidates the exact cache", async () => {
 		const dir = join(
 			tmpdir(),
 			`opencode-balancer-cache-${crypto.randomUUID()}`,
@@ -137,7 +137,6 @@ describe("cache update invalidation", () => {
 				"@thelioo/opencode-balancer@latest",
 				"0.2.2",
 			);
-			const toasts: string[] = [];
 
 			const result = await checkAndInvalidateOutdatedPackageCache({
 				cacheDir: dir,
@@ -145,15 +144,11 @@ describe("cache update invalidation", () => {
 				fetchLatestVersion: async () => "0.2.3",
 				moduleUrl: pathToFileURL(join(latest.packageDir, "dist", "index.js"))
 					.href,
-				notify: async (message) => toasts.push(message),
 				packageName: PACKAGE_NAME,
 			});
 
 			expect(result.removed).toEqual([latest.root]);
 			expect(existsSync(latest.root)).toBe(false);
-			expect(toasts).toEqual([
-				"opencode-balancer v0.2.3 is ready. Restart opencode to update from v0.2.2.",
-			]);
 		} finally {
 			rmSync(dir, { force: true, recursive: true });
 		}
@@ -170,7 +165,6 @@ describe("cache update invalidation", () => {
 				"@thelioo/opencode-balancer@latest",
 				"0.2.2",
 			);
-			const toasts: string[] = [];
 
 			const result = await checkAndInvalidateOutdatedPackageCache({
 				cacheDir: dir,
@@ -178,14 +172,12 @@ describe("cache update invalidation", () => {
 				fetchLatestVersion: async () => undefined,
 				moduleUrl: pathToFileURL(join(latest.packageDir, "dist", "index.js"))
 					.href,
-				notify: async (message) => toasts.push(message),
 				packageName: PACKAGE_NAME,
 			});
 
 			expect(result.removed).toEqual([]);
 			expect(result.reason).toBe("latest-version-unavailable");
 			expect(existsSync(latest.root)).toBe(true);
-			expect(toasts).toEqual([]);
 		} finally {
 			rmSync(dir, { force: true, recursive: true });
 		}

--- a/test/server/index.test.ts
+++ b/test/server/index.test.ts
@@ -72,7 +72,6 @@ describe("server plugin config", () => {
 	test("creates fallback balancer hooks and tool", () => {
 		const hooks = createServerHooks({ client: {}, db: db() });
 
-		expect(hooks.event).toBeFunction();
 		expect(hooks.config).toBeFunction();
 		expect(hooks["chat.headers"]).toBeFunction();
 		expect(hooks["command.execute.before"]).toBeFunction();
@@ -80,28 +79,28 @@ describe("server plugin config", () => {
 		expect(hooks.tool?.balancer_command).toBeDefined();
 	});
 
-	test("runs the cache update check once after a root session is created", async () => {
+	test("runs the cache update check once on plugin load", async () => {
 		const calls: string[] = [];
-		const hooks = createServerHooks({
-			cacheUpdate: async () => calls.push("check"),
+		createServerHooks({
+			cacheUpdate: async () => {
+				calls.push("check");
+			},
 			client: {},
 			db: db(),
 		});
 
-		await hooks.event?.({
-			event: { properties: {}, type: "session.created" },
-		} as any);
-		await hooks.event?.({
-			event: { properties: {}, type: "session.created" },
-		} as any);
-		await hooks.event?.({
-			event: {
-				properties: { info: { parentID: "parent" } },
-				type: "session.created",
-			},
-		} as any);
+		await new Promise((resolve) => setTimeout(resolve, 5));
 
 		expect(calls).toEqual(["check"]);
+	});
+
+	test("does not run a cache update check without an updater", () => {
+		const hooks = createServerHooks({
+			client: {},
+			db: db(),
+		});
+
+		expect(hooks.config).toBeFunction();
 	});
 
 	test("chat headers marks requests for active accounts", async () => {


### PR DESCRIPTION
## Problema

O auto-updater nunca disparava: a versão anterior checava no hook `event` em `session.created`, mas o opencode não entrega esse evento ao `event` hook de um server plugin. Resultado: o sandbox `@latest` no cache ficava preso na versão antiga.