### PR TITLE
chore: dummy release to test startup auto-update

### DIFF
--- a/.changeset/dummy-autoupdate-live-test.md
+++ b/.changeset/dummy-autoupdate-live-test.md
@@ -1,0 +1,5 @@
+---
+"@thelioo/opencode-balancer": patch
+---
+
+Dummy patch release to verify the startup auto-update end to end.


### PR DESCRIPTION
Dummy patch changeset para testar o auto-update de startup ponta a ponta no npm.

Ao mergear, o CI versiona e publica uma nova versão, que vira o novo `latest` — usada para verificar se um plugin instalado se atualiza sozinho no próximo start do opencode.

**Importante:** só funciona para quem já está numa versão **com** o fix do #19 (a 0.2.7 publicada ainda tem o gatilho quebrado).