### PR TITLE
Fix npm trusted publishing release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       NPM_CONFIG_PROVENANCE: true
-      NODE_AUTH_TOKEN: ""
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6

--- a/test/release/workflow.test.ts
+++ b/test/release/workflow.test.ts
@@ -34,7 +34,7 @@ describe("release workflow", () => {
 		expect(workflow).toContain("- main");
 		expect(workflow).toContain("contents: write");
 		expect(workflow).toContain("id-token: write");
-		expect(workflow).toContain('NODE_AUTH_TOKEN: ""');
+		expect(workflow).not.toContain("NODE_AUTH_TOKEN");
 		expect(workflow).toContain("oven-sh/setup-bun@v2");
 		expect(workflow).toContain("npm install --global npm@latest");
 		expect(workflow).toContain("bun install --frozen-lockfile");


### PR DESCRIPTION
## Summary
- Remove empty NODE_AUTH_TOKEN from the release workflow so npm trusted publishing can use OIDC
- Update release workflow coverage to prevent reintroducing NODE_AUTH_TOKEN

## Test Plan
- bun test