### PR TITLE
fix: npm@latest + native npm publish for OIDC release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
           registry-url: https://registry.npmjs.org
 
       - name: Update npm for trusted publishing
-        run: npm install --global npm@10
+        run: npm install --global npm@latest
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -83,7 +83,7 @@ jobs:
 
       - name: Publish npm
         if: steps.npm_package.outputs.is_published == 'false'
-        run: bun run release
+        run: npm publish --access public
 
       - name: Ensure git tag
         env:

--- a/test/release/workflow.test.ts
+++ b/test/release/workflow.test.ts
@@ -36,10 +36,11 @@ describe("release workflow", () => {
 		expect(workflow).toContain("id-token: write");
 		expect(workflow).not.toContain("NODE_AUTH_TOKEN");
 		expect(workflow).toContain("oven-sh/setup-bun@v2");
-		expect(workflow).toContain("npm install --global npm@10");
+		expect(workflow).toContain("npm install --global npm@latest");
 		expect(workflow).toContain("bun install --frozen-lockfile");
 		expect(workflow).toContain("bun run version");
-		expect(workflow).toContain("bun run release");
+		expect(workflow).toContain("npm publish --access public");
+		expect(workflow).not.toContain("bun run release");
 		expect(workflow).not.toContain("changesets/action@v1");
 		expect(workflow).not.toContain("pull-requests: write");
 		expect(workflow).toContain("NPM_CONFIG_PROVENANCE: true");


### PR DESCRIPTION
## Problem

The Release workflow fails at publish with a misleading `E404 Not Found - PUT` on the scoped package (`@thelioo/opencode-balancer@0.2.10`), even though provenance signing succeeds.

## Root cause

The job pinned `npm install --global npm@10`. **npm 10 cannot perform npm's OIDC trusted-publishing token exchange** (requires >= 11.5.1). npm signs provenance via the GitHub OIDC token (which is why that step passed) but then falls back to the empty `.npmrc` authToken written by `setup-node` for the registry `PUT`, and npm answers unauthorized scoped `PUT`s with a 404 instead of 403.

## Fix

- `npm@10` → `npm@latest` (satisfies the >= 11.5.1 OIDC requirement) — the primary fix.
- Publish with native `npm publish --access public` instead of `changeset publish`, which supports OIDC directly and avoids the known changesets+OIDC flakiness on scoped packages (npm/cli#8976). Provenance is preserved via the existing `NPM_CONFIG_PROVENANCE: true`.

Trusted Publisher config, `repository.url`, and permissions were all already correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)