### PR TITLE
fix: drop npm self-upgrade breaking provenance publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,9 +28,6 @@ jobs:
           node-version: '24'
           registry-url: https://registry.npmjs.org
 
-      - name: Update npm for trusted publishing
-        run: npm install --global npm@latest
-
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
 

--- a/test/release/workflow.test.ts
+++ b/test/release/workflow.test.ts
@@ -36,7 +36,7 @@ describe("release workflow", () => {
 		expect(workflow).toContain("id-token: write");
 		expect(workflow).not.toContain("NODE_AUTH_TOKEN");
 		expect(workflow).toContain("oven-sh/setup-bun@v2");
-		expect(workflow).toContain("npm install --global npm@latest");
+		expect(workflow).not.toContain("npm install --global npm");
 		expect(workflow).toContain("bun install --frozen-lockfile");
 		expect(workflow).toContain("bun run version");
 		expect(workflow).toContain("npm publish --access public");


### PR DESCRIPTION
## Problem

After fixing the npm version (#25), the release now fails at `npm publish` with:

```
npm error code MODULE_NOT_FOUND
npm error Cannot find module 'sigstore'
npm error - .../node_modules/npm/node_modules/libnpmpublish/lib/provenance.js
```

## Root cause

`npm install -g npm@latest` self-upgrades npm **in place**, which corrupts npm's own bundled dependency tree and drops the `sigstore` module that `--provenance` needs ([npm/cli#9722](https://github.com/npm/cli/issues/9722)).

**Node 24.18.0 already bundles npm 11.16.0** — well past the >= 11.5.1 OIDC requirement — so the upgrade step was never needed.

## Fix

Remove the "Update npm for trusted publishing" step and use the pristine bundled npm. This keeps OIDC trusted publishing **and** provenance working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)