### PR TITLE
fix: ship TUI components as source to fix "No renderer found"

### DIFF
--- a/.changeset/fix-tui-renderer-context.md
+++ b/.changeset/fix-tui-renderer-context.md
@@ -1,0 +1,5 @@
+---
+"@thelioo/opencode-balancer": patch
+---
+
+Fix the balancer dashboard crashing with "No renderer found". The TUI components are now shipped as source so opencode's runtime plugin transforms them at load time and they share opencode's `@opentui/solid` renderer context, while the entrypoint stays compiled so the plugin still initializes.

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -4,16 +4,7 @@ import solidTransformPlugin from "@opentui/solid/bun-plugin";
 await rm("dist", { force: true, recursive: true });
 
 const result = await Bun.build({
-	entrypoints: [
-		"./src/index.ts",
-		"./src/tui/tui.tsx",
-		"./src/tui/components/dashboard.tsx",
-		"./src/tui/components/priority-screen.tsx",
-		"./src/tui/components/provider-model-dialog.tsx",
-		"./src/tui/components/rename-dialog.tsx",
-		"./src/tui/components/sidebar.tsx",
-		"./src/tui/components/status-indicator.tsx",
-	],
+	entrypoints: ["./src/index.ts", "./src/tui/tui.tsx"],
 	external: [
 		"./components/*",
 		"@opencode-ai/plugin",
@@ -42,6 +33,8 @@ if (!result.success) {
 	for (const log of result.logs) console.error(log);
 	process.exit(1);
 }
+
+await import("./copy-tui-source");
 
 for (const output of result.outputs) {
 	if (!output.path.endsWith(".map")) continue;

--- a/scripts/copy-tui-source.ts
+++ b/scripts/copy-tui-source.ts
@@ -1,0 +1,50 @@
+import {
+	copyFileSync,
+	existsSync,
+	mkdirSync,
+	readdirSync,
+	rmSync,
+	statSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = fileURLToPath(new URL("..", import.meta.url));
+const coreSourceRoot = join(root, "src", "core");
+const coreTargetRoot = join(root, "dist", "core");
+const serverSourceRoot = join(root, "src", "server");
+const serverTargetRoot = join(root, "dist", "server");
+const tuiSourceRoot = join(root, "src", "tui");
+const tuiTargetRoot = join(root, "dist", "tui");
+
+function copySource(sourceDir: string, targetDir: string) {
+	mkdirSync(targetDir, { recursive: true });
+
+	for (const entry of readdirSync(sourceDir)) {
+		const sourcePath = join(sourceDir, entry);
+		const targetPath = join(targetDir, entry);
+		const stats = statSync(sourcePath);
+
+		if (stats.isDirectory()) {
+			copySource(sourcePath, targetPath);
+			continue;
+		}
+
+		if (!/\.tsx?$/.test(entry)) continue;
+		mkdirSync(dirname(targetPath), { recursive: true });
+		copyFileSync(sourcePath, targetPath);
+
+		if (/\.tsx$/.test(entry) && entry !== "tui.tsx") {
+			rmGeneratedFile(targetPath.replace(/\.tsx$/, ".js"));
+			rmGeneratedFile(targetPath.replace(/\.tsx$/, ".js.map"));
+		}
+	}
+}
+
+function rmGeneratedFile(path: string) {
+	if (existsSync(path)) rmSync(path);
+}
+
+copySource(coreSourceRoot, coreTargetRoot);
+copySource(serverSourceRoot, serverTargetRoot);
+copySource(tuiSourceRoot, tuiTargetRoot);

--- a/src/tui/tui.tsx
+++ b/src/tui/tui.tsx
@@ -51,15 +51,19 @@ const tui: TuiPlugin = async (api) => {
 		sidebarModule,
 		statusIndicatorModule,
 	] = await Promise.all([
-		import("./components/dashboard.js") as Promise<DashboardModule>,
-		import("./components/priority-screen.js") as Promise<PriorityScreenModule>,
+		import("./components/dashboard" + ".tsx") as Promise<DashboardModule>,
 		import(
-			"./components/provider-model-dialog.js"
+			"./components/priority-screen" + ".tsx"
+		) as Promise<PriorityScreenModule>,
+		import(
+			"./components/provider-model-dialog" + ".tsx"
 		) as Promise<ProviderModelDialogModule>,
-		import("./components/rename-dialog.js") as Promise<RenameDialogModule>,
-		import("./components/sidebar.js") as Promise<SidebarModule>,
 		import(
-			"./components/status-indicator.js"
+			"./components/rename-dialog" + ".tsx"
+		) as Promise<RenameDialogModule>,
+		import("./components/sidebar" + ".tsx") as Promise<SidebarModule>,
+		import(
+			"./components/status-indicator" + ".tsx"
 		) as Promise<StatusIndicatorModule>,
 	]);
 	const state = createBalancerTuiState();

--- a/test/tui/dist-artifact.test.ts
+++ b/test/tui/dist-artifact.test.ts
@@ -37,19 +37,27 @@ describe("TUI artifacts", () => {
 		expect(priorityRoute).toContain("applyNativeSelection: false");
 	});
 
-	test("uses compiled JavaScript for the built TUI export", () => {
+	test("compiles the TUI entrypoint but ships components as source", () => {
 		const distDir = join(import.meta.dir, "../../dist");
 		if (!existsSync(distDir)) return;
 
-		const artifact = join(import.meta.dir, "../../dist/tui/tui.js");
-		const dashboardArtifact = join(
+		// The entrypoint is compiled so opencode can initialize the plugin.
+		const entrypoint = join(import.meta.dir, "../../dist/tui/tui.js");
+		expect(existsSync(entrypoint)).toBe(true);
+
+		// Components ship as .tsx source so opencode's runtime plugin transforms
+		// them at load time and they share opencode's @opentui/solid renderer
+		// context. Compiling them breaks that sharing ("No renderer found").
+		const dashboardSource = join(
+			import.meta.dir,
+			"../../dist/tui/components/dashboard.tsx",
+		);
+		const dashboardCompiled = join(
 			import.meta.dir,
 			"../../dist/tui/components/dashboard.js",
 		);
-		const copiedSource = join(import.meta.dir, "../../dist/tui/tui.tsx");
-		expect(existsSync(artifact)).toBe(true);
-		expect(existsSync(dashboardArtifact)).toBe(true);
-		expect(existsSync(copiedSource)).toBe(false);
+		expect(existsSync(dashboardSource)).toBe(true);
+		expect(existsSync(dashboardCompiled)).toBe(false);
 	});
 
 	test("keeps OpenTUI component rendering out of the TUI entry artifact", () => {


### PR DESCRIPTION
## Problem

Navigating to the balancer dashboard crashes the opencode TUI:

```
Error: No renderer found
    at createElement (@opentui/solid/index.js)
    at dist/tui/components/dashboard.js
```

`0.2.10` shipped this bug.

## Root cause

`@opentui/solid` tracks its renderer via `RendererContext = createContext()` — a **per-module-instance singleton**. `useContext(RendererContext)` only resolves if the dashboard's `@opentui/solid` is the *same* instance opencode used to set up the provider. opencode guarantees that by transforming plugin TUI code **at load time** (its runtime plugin).

PR #22 ("export compiled TUI entrypoint") changed the component dynamic imports from `.tsx` source to pre-compiled `.js`. Compiled components bypass opencode's load-time transform and resolve a *different* `@opentui/solid` instance → `RendererContext` mismatch → **"No renderer found"**. #22 also deleted `scripts/copy-tui-source.ts`, which used to ship components as source.

#22 compiled everything to fix a plugin **initialization** failure — but only the **entrypoint** needed compiling; compiling the **components** broke rendering.

## Fix (hybrid)

- **Entrypoint stays compiled** (`dist/tui/tui.js`) → plugin still initializes.
- **Components ship as `.tsx` source** again (restore `copy-tui-source.ts`, `.tsx` dynamic imports) → opencode transforms them at load, sharing its renderer context.

## Verification

- Confirmed fixed by running the dashboard locally in opencode 1.17.18 (no more crash).
- 235/235 tests pass; typecheck + lint clean.
- `dist-artifact` test updated to assert the hybrid layout (compiled entrypoint + source components).

🤖 Generated with [Claude Code](https://claude.com/claude-code)