### PR TITLE
fix: restore Balancer TUI on OpenCode 1.17.18 (Windows load, navigation, highlight, post-connect freeze)

### DIFF
--- a/.changeset/nervous-bears-punch.md
+++ b/.changeset/nervous-bears-punch.md
@@ -1,0 +1,11 @@
+---
+"@thelioo/opencode-balancer": patch
+---
+
+Fix the Balancer TUI on OpenCode 1.17.18:
+
+- Register the dashboard command through OpenCode's TUI command shim (`api.command.register`) when available so `/balancer`, `Ctrl+B`, and the "Open Balancer Dashboard" palette entry appear again, keeping the keymap layer as a fallback for newer runtimes.
+- Fix dashboard arrow-key navigation resetting the selection every ~500ms: the dashboard poll re-set its `accounts` and `usage` signals with fresh identities on every tick, which made OpenCode re-render (remount) the route and reset the cursor. The poll now only updates those signals when the underlying data actually changed.
+- Fix the selected-row highlight being invisible on themes with a transparent `backgroundElement`. The selection now uses the theme's `primary` color with an opencode-style selected foreground, matching how opencode highlights its own list selections.
+- Fix the dashboard appearing frozen after adding an account: opencode opens (and briefly keeps re-opening) its native model picker on top of the dashboard after a provider connects, capturing the keyboard until the user pressed Esc. The connect flow now dismisses that lingering picker so control returns to the dashboard automatically.
+- Use Windows-specific environment fallbacks (`USERPROFILE`, `HOMEDRIVE`/`HOMEPATH`, `LOCALAPPDATA`) when resolving the config and data directories so the plugin initializes on Windows.

--- a/src/core/path.ts
+++ b/src/core/path.ts
@@ -3,15 +3,29 @@ function joinPath(...parts: string[]) {
 }
 
 function homeDir() {
-	return Bun.env.HOME || "/";
+	return (
+		Bun.env.HOME ||
+		Bun.env.USERPROFILE ||
+		(Bun.env.HOMEDRIVE && Bun.env.HOMEPATH
+			? `${Bun.env.HOMEDRIVE}${Bun.env.HOMEPATH}`
+			: "/")
+	);
 }
 
 function xdgConfigHome() {
-	return Bun.env.XDG_CONFIG_HOME || joinPath(homeDir(), ".config");
+	return (
+		Bun.env.XDG_CONFIG_HOME ||
+		Bun.env.LOCALAPPDATA ||
+		joinPath(homeDir(), ".config")
+	);
 }
 
 function xdgDataHome() {
-	return Bun.env.XDG_DATA_HOME || joinPath(homeDir(), ".local", "share");
+	return (
+		Bun.env.XDG_DATA_HOME ||
+		Bun.env.LOCALAPPDATA ||
+		joinPath(homeDir(), ".local", "share")
+	);
 }
 
 export function configDir() {

--- a/src/tui/components/dashboard.tsx
+++ b/src/tui/components/dashboard.tsx
@@ -86,19 +86,32 @@ export function Dashboard(props: {
 		Math.max(0, Math.min(value, Math.max(0, rows().length - 1)));
 	const clampHeaderCursor = (value: number) =>
 		Math.max(0, Math.min(value, headerActions.length - 1));
+	let accountsSig = "";
+	let usageSig = "";
 	const refreshDashboard = () => {
 		const nextAccounts = listAccounts(props.state.db);
-		setAccounts(nextAccounts);
-		setBalancing(getBalancingEnabled(props.state.db));
-		setUsage(
-			Object.fromEntries(
-				nextAccounts.map((account) => [
-					`${account.providerID}/${account.alias}`,
-					getUsageSnapshot(props.state.db, account.providerID, account.alias),
-				]),
-			),
+		const nextUsage = Object.fromEntries(
+			nextAccounts.map((account) => [
+				`${account.providerID}/${account.alias}`,
+				getUsageSnapshot(props.state.db, account.providerID, account.alias),
+			]),
 		);
-		setCursor((value) => clampCursor(value));
+		const nextAccountsSig = JSON.stringify(nextAccounts);
+		const nextUsageSig = JSON.stringify(nextUsage);
+		// Only push new object/array identities into the signals when the data
+		// actually changed. Re-setting them every tick notifies subscribers and
+		// makes opencode's route re-render (remounting this component and
+		// resetting the selection cursor).
+		if (nextAccountsSig !== accountsSig) {
+			accountsSig = nextAccountsSig;
+			setAccounts(nextAccounts);
+			setCursor((value) => clampCursor(value));
+		}
+		if (nextUsageSig !== usageSig) {
+			usageSig = nextUsageSig;
+			setUsage(nextUsage);
+		}
+		setBalancing(getBalancingEnabled(props.state.db));
 	};
 	refreshDashboard();
 	const timer = setInterval(refreshDashboard, 500);

--- a/src/tui/connect.ts
+++ b/src/tui/connect.ts
@@ -22,7 +22,7 @@ type ConnectApi = {
 		dispatchCommand?: (command: string) => unknown;
 	};
 	ui?: {
-		dialog?: { open?: boolean };
+		dialog?: { open?: boolean; clear?: () => unknown };
 		toast?: (input: {
 			variant: "success" | "error";
 			message: string;
@@ -86,6 +86,21 @@ async function waitForChangedProvider(
 	}
 }
 
+async function dismissLingeringDialog(api: ConnectApi) {
+	const dialog = api.ui?.dialog;
+	if (!dialog?.clear) return;
+	const wait =
+		api.wait ??
+		((ms: number) => new Promise((resolve) => setTimeout(resolve, ms)));
+	// opencode keeps re-opening the model picker for a short while after a
+	// provider connects, so clear it whenever it appears across a fixed window
+	// rather than stopping the moment it is briefly closed.
+	for (let attempt = 0; attempt < 20; attempt++) {
+		if (dialog.open) dialog.clear();
+		await wait(150);
+	}
+}
+
 export async function openNativeConnect(api: ConnectApi) {
 	if (api.keymap?.dispatchCommand) {
 		const readAuth = api.readAuth ?? readNativeAuth;
@@ -114,6 +129,12 @@ export async function openNativeConnect(api: ConnectApi) {
 							api.generateAlias ?? generatedAlias,
 						);
 					const account = saveAccount(api.db, providerID, alias, auth);
+					// After a provider connects, opencode opens (and keeps
+					// re-opening) its native model picker on top of the dashboard,
+					// which captures the keyboard and leaves the dashboard
+					// unresponsive until the user presses Esc. Dismiss it so control
+					// returns to the dashboard automatically.
+					await dismissLingeringDialog(api);
 					api.ui?.toast?.({
 						message: `Saved ${account.providerID}/${account.alias}.`,
 						variant: "success",

--- a/src/tui/selection-colors.ts
+++ b/src/tui/selection-colors.ts
@@ -1,30 +1,60 @@
-export function selectedRowColors<TColor>(theme: {
-	text: TColor;
-	textMuted?: TColor;
-	backgroundElement: TColor;
+// Mirrors opencode's own selected-list-item styling: a selected row is painted
+// with the theme's `primary` colour and a foreground picked the same way
+// opencode's `selectedForeground` does. Using `backgroundElement` (as this used
+// to) is invisible on themes where the element/background colours are
+// transparent, so the selection highlight would not show at all.
+
+type SelectionTheme<TColor> = {
+	primary: TColor;
 	background?: TColor;
-	accent?: TColor;
-}) {
-	const bg = theme.backgroundElement;
-	const textContrast = contrast(theme.text, bg);
-	const backgroundContrast =
-		theme.background === undefined ? undefined : contrast(theme.background, bg);
-	const fg =
-		backgroundContrast !== undefined && backgroundContrast > textContrast
-			? theme.background
-			: theme.text;
-	return { bg, fg };
+	selectedListItemText?: TColor;
+	_hasSelectedListItemText?: boolean;
+};
+
+export function selectedRowColors<TColor>(theme: SelectionTheme<TColor>): {
+	bg: TColor;
+	fg: TColor | string;
+} {
+	const bg = theme.primary;
+	return { bg, fg: selectedForeground(theme, bg) };
 }
 
-function contrast<TColor>(a: TColor, b: TColor) {
-	const ca = channels(a);
-	const cb = channels(b);
-	if (!ca || !cb) return 0;
-	const la = luminance(ca);
-	const lb = luminance(cb);
-	const lighter = Math.max(la, lb);
-	const darker = Math.min(la, lb);
-	return (lighter + 0.05) / (darker + 0.05);
+function selectedForeground<TColor>(
+	theme: SelectionTheme<TColor>,
+	bg: TColor,
+): TColor | string {
+	// Themes that explicitly define the selected text colour win.
+	if (
+		theme._hasSelectedListItemText &&
+		theme.selectedListItemText !== undefined
+	) {
+		return theme.selectedListItemText;
+	}
+	// On transparent-background themes there is no usable background colour to
+	// read the foreground from, so contrast against the selection background.
+	if (alpha(theme.background) === 0) {
+		const target = channels(bg);
+		if (target) {
+			const relative =
+				(0.299 * target.r + 0.587 * target.g + 0.114 * target.b) / 255;
+			return relative > 0.5 ? "#000000" : "#ffffff";
+		}
+	}
+	return theme.background ?? bg;
+}
+
+function alpha(value: unknown) {
+	if (!value || typeof value !== "object") return undefined;
+	const color = value as {
+		a?: unknown;
+		alpha?: unknown;
+		buffer?: ArrayLike<number>;
+	};
+	if (color.buffer && typeof color.buffer[3] === "number") {
+		return color.buffer[3];
+	}
+	const a = color.a ?? color.alpha;
+	return typeof a === "number" ? a : undefined;
 }
 
 function channels(value: unknown) {
@@ -42,12 +72,4 @@ function numberChannel(value: unknown) {
 	return typeof value === "number" && Number.isFinite(value)
 		? Math.max(0, Math.min(255, value))
 		: undefined;
-}
-
-function luminance(color: { r: number; g: number; b: number }) {
-	const [r, g, b] = [color.r, color.g, color.b].map((channel) => {
-		const value = channel / 255;
-		return value <= 0.03928 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4;
-	});
-	return 0.2126 * r + 0.7152 * g + 0.0722 * b;
 }

--- a/src/tui/tui.tsx
+++ b/src/tui/tui.tsx
@@ -169,22 +169,39 @@ const tui: TuiPlugin = async (api) => {
 	]);
 	api.lifecycle.onDispose(unregisterDashboard);
 
-	const unregisterKeymap = api.keymap.registerLayer({
-		bindings: [{ cmd: "balancer.dashboard.open", key: "ctrl+b" }],
-		commands: [
+	if (api.command) {
+		const unregisterCommand = api.command.register(() => [
 			{
 				category: "Plugin",
-				name: "balancer.dashboard.open",
-				namespace: "palette",
-				run() {
+				description: "Open the Balancer dashboard.",
+				keybind: "ctrl+b",
+				onSelect() {
 					openDashboard();
 				},
-				slashName: "balancer",
+				slash: { name: "balancer" },
 				title: "Open Balancer Dashboard",
+				value: "balancer.dashboard.open",
 			},
-		],
-	});
-	api.lifecycle.onDispose(unregisterKeymap);
+		]);
+		api.lifecycle.onDispose(unregisterCommand);
+	} else {
+		const unregisterKeymap = api.keymap.registerLayer({
+			bindings: [{ cmd: "balancer.dashboard.open", key: "ctrl+b" }],
+			commands: [
+				{
+					category: "Plugin",
+					name: "balancer.dashboard.open",
+					namespace: "palette",
+					run() {
+						openDashboard();
+					},
+					slashName: "balancer",
+					title: "Open Balancer Dashboard",
+				},
+			],
+		});
+		api.lifecycle.onDispose(unregisterKeymap);
+	}
 
 	api.slots.register({
 		slots: {

--- a/test/core/path.test.ts
+++ b/test/core/path.test.ts
@@ -1,7 +1,12 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { configDir } from "../../src/core/path";
+import { configDir, dataDir } from "../../src/core/path";
 
 const originalConfigDir = Bun.env.OPENCODE_CONFIG_DIR;
+const originalDataHome = Bun.env.XDG_DATA_HOME;
+const originalHome = Bun.env.HOME;
+const originalLocalAppData = Bun.env.LOCALAPPDATA;
+const originalUserProfile = Bun.env.USERPROFILE;
+const originalXdgConfigHome = Bun.env.XDG_CONFIG_HOME;
 
 afterEach(() => {
 	if (originalConfigDir === undefined) {
@@ -9,6 +14,16 @@ afterEach(() => {
 	} else {
 		Bun.env.OPENCODE_CONFIG_DIR = originalConfigDir;
 	}
+	if (originalDataHome === undefined) delete Bun.env.XDG_DATA_HOME;
+	else Bun.env.XDG_DATA_HOME = originalDataHome;
+	if (originalHome === undefined) delete Bun.env.HOME;
+	else Bun.env.HOME = originalHome;
+	if (originalLocalAppData === undefined) delete Bun.env.LOCALAPPDATA;
+	else Bun.env.LOCALAPPDATA = originalLocalAppData;
+	if (originalUserProfile === undefined) delete Bun.env.USERPROFILE;
+	else Bun.env.USERPROFILE = originalUserProfile;
+	if (originalXdgConfigHome === undefined) delete Bun.env.XDG_CONFIG_HOME;
+	else Bun.env.XDG_CONFIG_HOME = originalXdgConfigHome;
 });
 
 describe("path helpers", () => {
@@ -16,5 +31,17 @@ describe("path helpers", () => {
 		Bun.env.OPENCODE_CONFIG_DIR = "/tmp//opencode///config";
 
 		expect(configDir()).toBe("/tmp/opencode/config");
+	});
+
+	test("uses Windows config and data env vars when XDG and HOME are unavailable", () => {
+		delete Bun.env.OPENCODE_CONFIG_DIR;
+		delete Bun.env.XDG_CONFIG_HOME;
+		delete Bun.env.XDG_DATA_HOME;
+		delete Bun.env.HOME;
+		Bun.env.LOCALAPPDATA = String.raw`C:\Users\me\AppData\Local`;
+		Bun.env.USERPROFILE = String.raw`C:\Users\me`;
+
+		expect(configDir()).toBe(String.raw`C:\Users\me\AppData\Local/opencode`);
+		expect(dataDir()).toBe(String.raw`C:\Users\me\AppData\Local/opencode`);
 	});
 });

--- a/test/tui/connect.test.ts
+++ b/test/tui/connect.test.ts
@@ -95,6 +95,64 @@ describe("openNativeConnect", () => {
 		rmSync(dir, { force: true, recursive: true });
 	});
 
+	test("dismisses opencode's lingering model picker after saving a new account", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "opencode-balancer-connect-"));
+		const path = join(dir, "balancer.sqlite");
+		const db = openBalancerDatabase(path);
+		migrate(db);
+		const before = {
+			access: "old",
+			expires: 1,
+			refresh: "old",
+			type: "oauth",
+		} satisfies AuthInfo;
+		const after = {
+			access: "new",
+			expires: 2,
+			refresh: "new",
+			type: "oauth",
+		} satisfies AuthInfo;
+		let reads = 0;
+		let open = true;
+		let clears = 0;
+		let reopens = 1;
+		const dialog = {
+			clear: () => {
+				clears += 1;
+				open = false;
+			},
+			get open() {
+				return open;
+			},
+		};
+
+		await openNativeConnect({
+			db,
+			generateAlias: () => "a1b2c",
+			keymap: { dispatchCommand: async () => undefined },
+			readAuth: () => ({
+				auth: { openai: reads++ === 0 ? before : after },
+				ok: true,
+			}),
+			ui: { dialog, toast: () => {} },
+			// opencode reopens the model picker once right after it is cleared.
+			wait: async () => {
+				if (clears >= 1 && reopens > 0) {
+					open = true;
+					reopens -= 1;
+				}
+			},
+		});
+
+		expect(open).toBe(false);
+		expect(clears).toBeGreaterThanOrEqual(2);
+		expect(listAccounts(db, "openai")).toMatchObject([
+			{ alias: "a1b2c", providerID: "openai" },
+		]);
+		closeBalancerDatabase(path);
+		rmSync(dir, { force: true, recursive: true });
+	});
+
 	test("waits for native auth to change after the provider dialog finishes later", async () => {
 		const dir = mkdtempSync(join(tmpdir(), "opencode-balancer-connect-"));
 		const path = join(dir, "balancer.sqlite");

--- a/test/tui/selection-colors.test.ts
+++ b/test/tui/selection-colors.test.ts
@@ -2,32 +2,59 @@ import { describe, expect, test } from "bun:test";
 import { selectedRowColors } from "../../src/tui/selection-colors";
 
 describe("selectedRowColors", () => {
-	test("uses UI background colors instead of accent as the selected row background", () => {
+	test("paints the selected row with the theme primary color", () => {
 		const theme = {
-			accent: "accent",
+			_hasSelectedListItemText: true,
 			background: "background",
-			backgroundElement: "backgroundElement",
-			text: "text",
+			primary: "primary",
+			selectedListItemText: "selected-text",
 		};
 
 		expect(selectedRowColors(theme)).toEqual({
-			bg: "backgroundElement",
-			fg: "text",
+			bg: "primary",
+			fg: "selected-text",
 		});
 	});
 
-	test("chooses the foreground with stronger contrast for RGB colors", () => {
+	test("falls back to the background foreground on opaque themes without selected text", () => {
 		const theme = {
-			accent: { a: 255, b: 230, g: 255, r: 255 },
-			background: { a: 255, b: 30, g: 0, r: 48 },
-			backgroundElement: { a: 255, b: 55, g: 23, r: 82 },
-			text: { a: 255, b: 245, g: 245, r: 245 },
-			textMuted: { a: 255, b: 150, g: 150, r: 150 },
+			_hasSelectedListItemText: false,
+			background: "background",
+			primary: "primary",
+			selectedListItemText: "background",
 		};
 
 		expect(selectedRowColors(theme)).toEqual({
-			bg: theme.backgroundElement,
-			fg: theme.text,
+			bg: "primary",
+			fg: "background",
+		});
+	});
+
+	test("contrasts against a light primary on transparent-background themes", () => {
+		const theme = {
+			_hasSelectedListItemText: false,
+			background: { a: 0, b: 0, g: 0, r: 0 },
+			primary: { a: 255, b: 43, g: 91, r: 236 },
+			selectedListItemText: { a: 0, b: 0, g: 0, r: 0 },
+		};
+
+		expect(selectedRowColors(theme)).toEqual({
+			bg: theme.primary,
+			fg: "#000000",
+		});
+	});
+
+	test("contrasts against a dark primary on transparent-background themes", () => {
+		const theme = {
+			_hasSelectedListItemText: false,
+			background: { a: 0, b: 0, g: 0, r: 0 },
+			primary: { a: 255, b: 20, g: 20, r: 20 },
+			selectedListItemText: { a: 0, b: 0, g: 0, r: 0 },
+		};
+
+		expect(selectedRowColors(theme)).toEqual({
+			bg: theme.primary,
+			fg: "#ffffff",
 		});
 	});
 });


### PR DESCRIPTION
## Summary

Fixes the Balancer TUI on OpenCode `1.17.18`, starting with the Windows load failure reported in #28 and covering the follow-up regressions found while verifying the fix in a real TUI session.

## Problems & fixes

### 1. TUI entry points never appear (`/balancer`, `Ctrl+B`, palette) — #28
On OpenCode 1.17.18 the dashboard command was only registered through `api.keymap.registerLayer`, which no longer surfaces the slash command / palette entry reliably.
**Fix:** register the command through OpenCode's TUI command shim (`api.command.register`) when it's available, keeping the keymap layer as a fallback for newer runtimes.

### 2. Plugin does not initialize on Windows — #28
Path resolution only fell back to `HOME`, which is often unset on Windows, so the config/data directories resolved to `/…` and initialization failed before any TUI surface registered.
**Fix:** fall back to `USERPROFILE`, `HOMEDRIVE`+`HOMEPATH`, and `LOCALAPPDATA` when the XDG/`HOME` variables are missing.

### 3. Dashboard arrow-key navigation resets every ~500ms
The dashboard poll re-set its `accounts` and `usage` signals with fresh object identities on every tick. That notified subscribers and made OpenCode re-render (remount) the whole route, resetting the selection cursor to the top — so the cursor "moved and snapped back". Confirmed at runtime: a new component instance mounted every ~500ms.
**Fix:** only update those signals when the underlying data actually changed.

### 4. Selected-row highlight is invisible
The selection used `theme.backgroundElement`, which is fully transparent (`rgba(0,0,0,0)`) on transparent-background themes, so nothing was painted. Confirmed at runtime (no background SGR emitted).
**Fix:** paint the selected row with `theme.primary` plus an opencode-style selected foreground (`selectedForeground`), matching how OpenCode highlights its own list selections.

### 5. Dashboard appears frozen after adding an account
After a provider connects, OpenCode opens (and keeps re-opening for ~1–2s) its native model picker on top of the dashboard, which captures the keyboard until the user presses `Esc`. Reproduced end-to-end via the API-key connect flow.
**Fix:** after the connect flow saves the account, dismiss the lingering picker across a short window so control returns to the dashboard automatically.

## Verification

- `bun run build`, `bun run checktypes`, `bun test` — 239 passing (added regression tests for the connect dismissal and the selection colours).
- Each behavioural fix (navigation, highlight, model-picker dismissal) was verified in a real OpenCode 1.17.18 TUI session by driving the terminal and inspecting the rendered frames.

Closes #28
