### PR TITLE
fix: register balancer TUI command through keymap

### DIFF
--- a/.changeset/short-ravens-jam.md
+++ b/.changeset/short-ravens-jam.md
@@ -1,0 +1,5 @@
+---
+"@thelioo/opencode-balancer": patch
+---
+
+Register the Balancer dashboard command through OpenCode's current TUI keymap API so `/balancer`, `Ctrl+B`, and the command palette work on OpenCode 1.17.18.

--- a/src/tui/tui.tsx
+++ b/src/tui/tui.tsx
@@ -169,39 +169,22 @@ const tui: TuiPlugin = async (api) => {
 	]);
 	api.lifecycle.onDispose(unregisterDashboard);
 
-	if (api.command) {
-		const unregisterCommand = api.command.register(() => [
+	const unregisterKeymap = api.keymap.registerLayer({
+		bindings: [{ cmd: "balancer.dashboard.open", key: "ctrl+b" }],
+		commands: [
 			{
 				category: "Plugin",
-				description: "Open the Balancer dashboard.",
-				keybind: "ctrl+b",
-				onSelect() {
+				name: "balancer.dashboard.open",
+				namespace: "palette",
+				run() {
 					openDashboard();
 				},
-				slash: { name: "balancer" },
+				slashName: "balancer",
 				title: "Open Balancer Dashboard",
-				value: "balancer.dashboard.open",
 			},
-		]);
-		api.lifecycle.onDispose(unregisterCommand);
-	} else {
-		const unregisterKeymap = api.keymap.registerLayer({
-			bindings: [{ cmd: "balancer.dashboard.open", key: "ctrl+b" }],
-			commands: [
-				{
-					category: "Plugin",
-					name: "balancer.dashboard.open",
-					namespace: "palette",
-					run() {
-						openDashboard();
-					},
-					slashName: "balancer",
-					title: "Open Balancer Dashboard",
-				},
-			],
-		});
-		api.lifecycle.onDispose(unregisterKeymap);
-	}
+		],
+	});
+	api.lifecycle.onDispose(unregisterKeymap);
 
 	api.slots.register({
 		slots: {

--- a/test/tui/tui.test.ts
+++ b/test/tui/tui.test.ts
@@ -29,6 +29,7 @@ function withTempConfigDir() {
 function createApi() {
 	const routes: TuiRouteDefinition[] = [];
 	const keymapLayers: any[] = [];
+	const legacyCommandCallbacks: any[] = [];
 	const navigations: unknown[] = [];
 	const toasts: unknown[] = [];
 	const dialogs: unknown[] = [];
@@ -40,6 +41,12 @@ function createApi() {
 			app: { version: "test" },
 			attention: {},
 			client: {},
+			command: {
+				register: (cb: any) => {
+					legacyCommandCallbacks.push(cb);
+					return () => {};
+				},
+			},
 			event: {},
 			keymap: {
 				registerLayer: (layer: any) => {
@@ -103,6 +110,7 @@ function createApi() {
 		dialogs,
 		disposes,
 		keymapLayers,
+		legacyCommandCallbacks,
 		navigations,
 		routes,
 		toasts,
@@ -160,6 +168,27 @@ describe("tui plugin", () => {
 		expect(toasts).toEqual([]);
 
 		for (const dispose of disposes) await dispose();
+	});
+
+	test("uses keymap registration even when legacy command api exists", async () => {
+		withTempConfigDir();
+		const { api, keymapLayers, legacyCommandCallbacks } = createApi();
+
+		await plugin.tui(api, undefined, {} as any);
+
+		expect(legacyCommandCallbacks).toEqual([]);
+		expect(keymapLayers).toHaveLength(1);
+		expect(keymapLayers[0].bindings).toContainEqual({
+			cmd: "balancer.dashboard.open",
+			key: "ctrl+b",
+		});
+		expect(keymapLayers[0].commands).toContainEqual(
+			expect.objectContaining({
+				name: "balancer.dashboard.open",
+				slashName: "balancer",
+				title: "Open Balancer Dashboard",
+			}),
+		);
 	});
 
 	test("passes dynamic session provider lookups to reactive sidebar/status handlers", async () => {


### PR DESCRIPTION
## Summary
- Register the Balancer dashboard command through the current OpenCode TUI keymap API instead of the legacy command API.
- Add regression coverage for environments where the legacy command API still exists.
- Add a patch changeset for the TUI command fix.

## Test Plan
- pnpm build
- pnpm checktypes
- bun test