### PR TITLE
fix: skip schema recreation when migration is already applied

### DIFF
--- a/.changeset/skip-migration-recreation-when-current.md
+++ b/.changeset/skip-migration-recreation-when-current.md
@@ -1,0 +1,5 @@
+---
+"@thelioo/opencode-balancer": patch
+---
+
+Skip schema table recreation when the migration is already applied, fixing "database is locked" and "no such table: accounts_new" races between concurrent server and TUI plugin instances.

--- a/src/core/schema.ts
+++ b/src/core/schema.ts
@@ -411,6 +411,70 @@ function recreateSettings(db: Database) {
     `);
 }
 
+const requiredColumns: Record<string, string[]> = {
+	accounts: [
+		"provider_id",
+		"alias",
+		"auth_json",
+		"auth_type",
+		"created_at",
+		"updated_at",
+		"last_used_at",
+		"rate_limited_until",
+		"failures",
+		"disabled",
+	],
+	events: [
+		"id",
+		"type",
+		"provider_id",
+		"alias",
+		"message",
+		"created_at",
+		"metadata_json",
+	],
+	pending_connections: [
+		"id",
+		"provider_id",
+		"auth_json",
+		"auth_type",
+		"source",
+		"captured_at",
+		"prompt_status",
+	],
+	provider_priority: [
+		"provider_id",
+		"position",
+		"model_id",
+		"enabled",
+		"updated_at",
+	],
+	provider_state: [
+		"provider_id",
+		"active_alias",
+		"updated_at",
+		"metadata_json",
+	],
+	settings: ["key", "value"],
+	usage_snapshots: [
+		"provider_id",
+		"alias",
+		"fetched_at",
+		"confidence",
+		"normalized_json",
+		"raw_redacted_json",
+		"error",
+	],
+};
+
+function schemaIsCurrent(db: Database) {
+	for (const [table, columns] of Object.entries(requiredColumns)) {
+		const existing = tableColumns(db, table);
+		if (columns.some((column) => !existing.has(column))) return false;
+	}
+	return true;
+}
+
 export function migrate(db: Database) {
 	db.exec(`
         CREATE TABLE IF NOT EXISTS schema_migrations (
@@ -418,6 +482,11 @@ export function migrate(db: Database) {
             applied_at INTEGER NOT NULL
         );
     `);
+
+	// Server and TUI plugin instances migrate the same database concurrently on
+	// every opencode start; recreating tables when nothing changed turns that
+	// into a lock/drop race ("database is locked", "no such table: accounts_new").
+	if (hasMigration(db, 1) && schemaIsCurrent(db)) return;
 
 	const apply = db.transaction(() => {
 		recreateAccounts(db);

--- a/test/core/schema.test.ts
+++ b/test/core/schema.test.ts
@@ -68,6 +68,23 @@ describe("schema migrations", () => {
 		expect(row?.count).toBe(1);
 	});
 
+	test("skips table recreation when the schema is already current", () => {
+		const db = openBalancerDatabase(tempDb());
+		migrate(db);
+
+		// Recreation starts with DROP TABLE IF EXISTS accounts_new, so a
+		// sentinel table only survives a second migrate() if it short-circuits.
+		db.exec("CREATE TABLE accounts_new (sentinel INTEGER)");
+		migrate(db);
+
+		const sentinel = db
+			.query<{ name: string }, []>(
+				"SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'accounts_new'",
+			)
+			.get();
+		expect(sentinel?.name).toBe("accounts_new");
+	});
+
 	test("repairs incomplete existing version one databases", () => {
 		const db = openBalancerDatabase(tempDb());
 		db.exec(`


### PR DESCRIPTION
## Summary
- migrate() returned early only for the version marker but still recreated every table on each database open; concurrent server/TUI plugin instances raced on DROP/RENAME, causing "database is locked" and "no such table: accounts_new" load failures.
- Skip recreation when schema_migrations records version 1 and all tables/columns are current, keeping the repair path for incomplete schemas.
- Add a sentinel-table regression test and verify with an 8-process concurrent migration stress run.

## Test Plan
- bun test (241 pass)
- 8 parallel processes x25 migrate() against one database: no errors, data preserved
- Real TUI check: /balancer appears in opencode 1.17.20