### PR TITLE
fix: read auth.json from opencode's xdg data dir on Windows

### DIFF
--- a/.changeset/windows-auth-path.md
+++ b/.changeset/windows-auth-path.md
@@ -1,0 +1,5 @@
+---
+"@thelioo/opencode-balancer": patch
+---
+
+Read auth.json from the same directory opencode writes it on Windows (`~/.local/share/opencode`, matching xdg-basedir) instead of `%LOCALAPPDATA%`, so accounts connected through the native provider flow are saved.

--- a/src/core/path.ts
+++ b/src/core/path.ts
@@ -1,3 +1,5 @@
+import { existsSync } from "node:fs";
+
 function joinPath(...parts: string[]) {
 	return parts.filter(Boolean).join("/").replace(/\/+/g, "/");
 }
@@ -12,20 +14,16 @@ function homeDir() {
 	);
 }
 
+// opencode resolves its directories with the xdg-basedir package, which
+// applies the XDG defaults on every platform — including Windows, where it
+// never consults LOCALAPPDATA. Mirror that so we read the same auth.json
+// opencode writes.
 function xdgConfigHome() {
-	return (
-		Bun.env.XDG_CONFIG_HOME ||
-		Bun.env.LOCALAPPDATA ||
-		joinPath(homeDir(), ".config")
-	);
+	return Bun.env.XDG_CONFIG_HOME || joinPath(homeDir(), ".config");
 }
 
 function xdgDataHome() {
-	return (
-		Bun.env.XDG_DATA_HOME ||
-		Bun.env.LOCALAPPDATA ||
-		joinPath(homeDir(), ".local", "share")
-	);
+	return Bun.env.XDG_DATA_HOME || joinPath(homeDir(), ".local", "share");
 }
 
 export function configDir() {
@@ -40,7 +38,19 @@ export function dataDir() {
 }
 
 export function storePath() {
-	return joinPath(configDir(), "balancer.sqlite");
+	const path = joinPath(configDir(), "balancer.sqlite");
+	if (existsSync(path)) return path;
+	// Older releases resolved the config dir to LOCALAPPDATA on Windows.
+	// Keep using a store created there so existing accounts are not lost.
+	const legacyRoot =
+		!Bun.env.OPENCODE_CONFIG_DIR &&
+		!Bun.env.XDG_CONFIG_HOME &&
+		Bun.env.LOCALAPPDATA;
+	if (legacyRoot) {
+		const legacy = joinPath(legacyRoot, "opencode", "balancer.sqlite");
+		if (existsSync(legacy)) return legacy;
+	}
+	return path;
 }
 
 export function nativeAuthPath() {

--- a/test/core/path.test.ts
+++ b/test/core/path.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { configDir, dataDir } from "../../src/core/path";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import {
+	configDir,
+	dataDir,
+	nativeAuthPath,
+	storePath,
+} from "../../src/core/path";
 
 const originalConfigDir = Bun.env.OPENCODE_CONFIG_DIR;
 const originalDataHome = Bun.env.XDG_DATA_HOME;
@@ -33,7 +39,11 @@ describe("path helpers", () => {
 		expect(configDir()).toBe("/tmp/opencode/config");
 	});
 
-	test("uses Windows config and data env vars when XDG and HOME are unavailable", () => {
+	test("matches opencode's xdg-basedir paths on Windows", () => {
+		// opencode resolves its dirs with the xdg-basedir package, which uses
+		// `~/.local/share` and `~/.config` on every platform — including
+		// Windows, where it never consults LOCALAPPDATA. The balancer must
+		// read auth.json from the same place opencode writes it (issue #36).
 		delete Bun.env.OPENCODE_CONFIG_DIR;
 		delete Bun.env.XDG_CONFIG_HOME;
 		delete Bun.env.XDG_DATA_HOME;
@@ -41,7 +51,32 @@ describe("path helpers", () => {
 		Bun.env.LOCALAPPDATA = String.raw`C:\Users\me\AppData\Local`;
 		Bun.env.USERPROFILE = String.raw`C:\Users\me`;
 
-		expect(configDir()).toBe(String.raw`C:\Users\me\AppData\Local/opencode`);
-		expect(dataDir()).toBe(String.raw`C:\Users\me\AppData\Local/opencode`);
+		expect(configDir()).toBe(String.raw`C:\Users\me/.config/opencode`);
+		expect(dataDir()).toBe(String.raw`C:\Users\me/.local/share/opencode`);
+		expect(nativeAuthPath()).toBe(
+			String.raw`C:\Users\me/.local/share/opencode/auth.json`,
+		);
+	});
+
+	test("keeps using a legacy LOCALAPPDATA store when one already exists", () => {
+		const root = `${import.meta.dir}/.tmp-path-test`;
+		rmSync(root, { force: true, recursive: true });
+		mkdirSync(`${root}/legacy/opencode`, { recursive: true });
+		writeFileSync(`${root}/legacy/opencode/balancer.sqlite`, "");
+		try {
+			delete Bun.env.OPENCODE_CONFIG_DIR;
+			delete Bun.env.XDG_CONFIG_HOME;
+			delete Bun.env.XDG_DATA_HOME;
+			delete Bun.env.HOME;
+			Bun.env.LOCALAPPDATA = `${root}/legacy`;
+			Bun.env.USERPROFILE = `${root}/home`;
+
+			expect(storePath()).toBe(`${root}/legacy/opencode/balancer.sqlite`);
+
+			rmSync(`${root}/legacy/opencode/balancer.sqlite`);
+			expect(storePath()).toBe(`${root}/home/.config/opencode/balancer.sqlite`);
+		} finally {
+			rmSync(root, { force: true, recursive: true });
+		}
 	});
 });


### PR DESCRIPTION
Fixes #36.

## Problem
On Windows, completing opencode's native provider connection flow gave no response and the account was never added.

## Root cause
opencode resolves its directories with the [xdg-basedir](https://github.com/sindresorhus/xdg-basedir) package, which uses `~/.local/share` and `~/.config` on **every** platform — it never consults `LOCALAPPDATA`. The balancer, however, preferred `LOCALAPPDATA` on Windows, so it watched `%LOCALAPPDATA%\opencode\auth.json` — a file opencode never writes. `readNativeAuth()` always saw an empty auth map, the connect flow never detected a change, and it timed out silently: no toast, no saved account. The server-side auth watcher was equally blind.

## Fix
- `xdgConfigHome()` / `xdgDataHome()` now mirror xdg-basedir exactly: `XDG_*` env var or the XDG default under the home directory, on all platforms.
- `storePath()` keeps using a `balancer.sqlite` previously created under `LOCALAPPDATA`, so existing Windows stores are not orphaned by the path change.

## Testing
- New test asserting Windows paths match opencode's xdg-basedir resolution (config, data, and `auth.json`).
- New test covering the legacy `LOCALAPPDATA` store fallback.
- `bun test` (242 pass), `tsgo --noEmit`, `biome check` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)