### PR TITLE
fix: keep TUI selection across host-driven route remounts

### DIFF
--- a/.changeset/fix-remount-navigation.md
+++ b/.changeset/fix-remount-navigation.md
@@ -1,0 +1,5 @@
+---
+"@thelioo/opencode-balancer": patch
+---
+
+Fix arrow-key navigation in the dashboard and priority screens when the plugin is installed from npm. opencode's route computation could track the screens' selection signals through opentui's runtime bridge, remounting the screen on every key press and resetting the selection; the selection state now lives at module scope so it survives those remounts.

--- a/src/tui/components/dashboard.tsx
+++ b/src/tui/components/dashboard.tsx
@@ -35,6 +35,16 @@ type DashboardRow =
 
 type HeaderAction = { type: "close" | "priority"; key: string; label: string };
 
+// Selection state lives at module scope on purpose: when the plugin is
+// installed from npm, opentui's runtime bridge can make opencode's reactive
+// route computation track signals read while this component mounts, so every
+// key press re-renders the route and remounts the component. Module-scoped
+// signals survive those remounts, keeping arrow navigation working.
+const [confirmAccount, setConfirmAccount] = createSignal<string | undefined>();
+const [cursor, setCursor] = createSignal(0);
+const [headerCursor, setHeaderCursor] = createSignal(0);
+const [focusArea, setFocusArea] = createSignal<DashboardFocusArea>("content");
+
 export function Dashboard(props: {
 	api: TuiPluginApi;
 	state: BalancerTuiState;
@@ -46,9 +56,6 @@ export function Dashboard(props: {
 }) {
 	const theme = () => props.api.theme.current;
 	const selectedColors = () => selectedRowColors(theme());
-	const [confirmAccount, setConfirmAccount] = createSignal<
-		string | undefined
-	>();
 	const [accounts, setAccounts] = createSignal(listAccounts(props.state.db));
 	const [balancing, setBalancing] = createSignal(
 		getBalancingEnabled(props.state.db),
@@ -56,9 +63,6 @@ export function Dashboard(props: {
 	const [usage, setUsage] = createSignal<
 		Record<string, ProviderUsageSnapshot | undefined>
 	>({});
-	const [cursor, setCursor] = createSignal(0);
-	const [headerCursor, setHeaderCursor] = createSignal(0);
-	const [focusArea, setFocusArea] = createSignal<DashboardFocusArea>("content");
 	const layoutMode = () =>
 		dashboardLayoutMode({
 			height: (props.api.renderer as unknown as { height?: number }).height,

--- a/src/tui/components/priority-screen.tsx
+++ b/src/tui/components/priority-screen.tsx
@@ -40,6 +40,11 @@ function modelLabel(api: TuiPluginApi, entry: PriorityEntry): string {
 	return model?.name ?? entry.modelID;
 }
 
+// Module scope so the selection survives host-driven route remounts; see the
+// note above the Dashboard selection signals.
+const [cursor, setCursor] = createSignal(0);
+const [focusArea, setFocusArea] = createSignal<PriorityFocusArea>("content");
+
 export function PriorityScreen(props: {
 	api: TuiPluginApi;
 	state: BalancerTuiState;
@@ -54,8 +59,6 @@ export function PriorityScreen(props: {
 		listProviderPriority(db),
 	);
 	const [balancing, setBalancing] = createSignal(getBalancingEnabled(db));
-	const [cursor, setCursor] = createSignal(0);
-	const [focusArea, setFocusArea] = createSignal<PriorityFocusArea>("content");
 	const compact = () =>
 		dashboardLayoutMode({
 			height: (props.api.renderer as unknown as { height?: number }).height,

--- a/test/tui/selection-persistence.test.ts
+++ b/test/tui/selection-persistence.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const read = (file: string) =>
+	readFileSync(join(import.meta.dir, "../../src/tui/components", file), "utf8");
+
+// When the plugin is installed from npm, opentui's runtime bridge can make
+// opencode's reactive computation track the signals these screens read while
+// mounting. Every cursor move then re-renders the route and remounts the
+// component, so selection state kept inside the component resets to the top
+// on each key press (arrow navigation appears dead). Keeping the selection
+// signals at module scope makes the screens remount-proof.
+describe("selection state survives route remounts", () => {
+	test("dashboard selection signals live at module scope", () => {
+		const source = read("dashboard.tsx");
+		const componentStart = source.indexOf("export function Dashboard(");
+		expect(componentStart).toBeGreaterThan(0);
+
+		for (const signal of [
+			"const [cursor, setCursor] = createSignal(",
+			"const [headerCursor, setHeaderCursor] = createSignal(",
+			"const [focusArea, setFocusArea] = createSignal<DashboardFocusArea>(",
+			"const [confirmAccount, setConfirmAccount] = createSignal<",
+		]) {
+			const index = source.indexOf(signal);
+			expect(index).toBeGreaterThan(0);
+			expect(index).toBeLessThan(componentStart);
+		}
+	});
+
+	test("priority screen selection signals live at module scope", () => {
+		const source = read("priority-screen.tsx");
+		const componentStart = source.indexOf("export function PriorityScreen(");
+		expect(componentStart).toBeGreaterThan(0);
+
+		for (const signal of [
+			"const [cursor, setCursor] = createSignal(",
+			"const [focusArea, setFocusArea] = createSignal<PriorityFocusArea>(",
+		]) {
+			const index = source.indexOf(signal);
+			expect(index).toBeGreaterThan(0);
+			expect(index).toBeLessThan(componentStart);
+		}
+	});
+});


### PR DESCRIPTION
## Problem
After v0.2.16, arrow-key navigation in the Balancer dashboard stopped working for npm installs: the highlight stayed stuck on "Automatic balancing" no matter which key was pressed.

## Root cause
v0.2.16 upgraded `@opentui/solid` from 0.2 to 0.4. When the plugin is installed from npm (files under `node_modules`), opentui's runtime bridge rewrites the runtime-compiled components' imports so they share opencode's solid instance. The host's route computation then tracks the signals the dashboard reads while mounting, so every `setCursor` invalidated that computation: the route re-rendered, the component remounted, and the selection reset to the top on every key press. Keys were actually being handled — the state just never survived the remount.

Loading the plugin from a local directory (`file:`, the dev setup) skips the rewrite, which is why the bug never reproduced from the repo checkout and only showed up in real npm installs.

An `untrack()` wrapper around the route render does not work: the precompiled `dist/tui/tui.js` and the runtime-compiled components end up with different solid-js instances, so tui.js's `untrack` nulls the wrong listener.

## Fix
Move the dashboard and priority screen selection signals (cursor, header cursor, focus area, pending removal confirmation) to module scope. The selection now survives host-driven remounts regardless of which solid instance ends up shared, and behavior is unchanged for `file:` installs.

## Testing
- New `test/tui/selection-persistence.test.ts` asserting the selection signals live at module scope in both screens.
- Full suite: 256 tests passing; types and lint clean.
- End-to-end: reproduced the bug and verified the fix against a real npm-installed layout (opencode 1.17.20 in an isolated tmux sandbox), and confirmed on the reporting machine — Down/Up move the selection, `p` opens the priority matrix, Esc returns keeping state.